### PR TITLE
Add CI for building the code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ROS2 CI (Build Only)
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distribution:
+          - galactic
+          - rolling
+        include:
+            # Galactic
+          - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-desktop-latest
+            ros_distribution: galactic
+            ros_version: 2
+            # Rolling
+          - docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-rolling-desktop-latest
+            ros_distribution: rolling
+            ros_version: 2
+    container:
+      image: ${{ matrix.docker_image }}
+    steps:
+      - name: Setup directories
+        run: mkdir -p ros_ws/src
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@0.2.1
+        with:
+          required-ros-distributions: ${{ matrix.ros_distribution }}
+      - name: Build and Test
+        uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          package-name: ""
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+          skip-tests: true


### PR DESCRIPTION
CI currently only builds the code and doesn't run any linters (there are no unit tests), since making the linter pass would require changing a large chunk of code. So to avoid that and keep the code in sync with upstream it is disabled.